### PR TITLE
Fix unlock config for purchase

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,7 +100,11 @@ export default function Home() {
 
       // Initialize Unlock.js service
       const unlockConfig = {
-        [NETWORK_ID]: { provider: BASE_RPC_URL, unlockAddress: LOCK_ADDRESS },
+        [NETWORK_ID]: {
+          provider: BASE_RPC_URL,
+          // Unlock contract address on Base mainnet
+          unlockAddress: '0xd0b14797b9D08493392865647384974470202A78',
+        },
       };
       const walletService = new WalletService(unlockConfig);
       console.log('Connecting Unlock service...');


### PR DESCRIPTION
## Summary
- fix unlock contract configuration for purchase

## Testing
- `npm run build` *(fails: Cannot initialize the Privy provider with an invalid Privy app ID)*

------
https://chatgpt.com/codex/tasks/task_e_688b4b5eacf48321876abdb3ced57bdb