### PR TITLE
Decode Unlock errors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePrivy, useWallets, useFundWallet } from '@privy-io/react-auth';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { BrowserProvider, Contract, JsonRpcProvider, parseUnits } from 'ethers';
 import { WalletService } from '@unlock-protocol/unlock-js';
 import { base } from 'viem/chains';
@@ -20,6 +20,31 @@ export default function Home() {
   const NETWORK_ID = 8453;
   const BASE_RPC_URL = 'https://mainnet.base.org';
   const USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+  const unlockConfig = useMemo(
+    () => ({
+      [NETWORK_ID]: {
+        provider: BASE_RPC_URL,
+        unlockAddress: '0xd0b14797b9D08493392865647384974470202A78',
+      },
+    }),
+    []
+  );
+  const walletService = useMemo(
+    () => new WalletService(unlockConfig),
+    [unlockConfig]
+  );
+
+  const UNLOCK_ERRORS: Record<string, string> = {
+    '0x17ed8646': 'Membership sold out or max keys reached.',
+    '0x31af6951': 'Lock sold out.',
+    '0x1f04ddc8': 'Not enough funds.',
+  };
+
+  const decodeUnlockError = (data: string) => {
+    const code = data.slice(0, 10).toLowerCase();
+    return UNLOCK_ERRORS[code] || data;
+  };
 
   // Check if connected wallet has membership
   const checkMembership = async () => {
@@ -99,15 +124,7 @@ export default function Home() {
       const browserProvider = new BrowserProvider(eip1193, NETWORK_ID);
       const signer = await browserProvider.getSigner();
 
-      // Initialize Unlock.js service
-      const unlockConfig = {
-        [NETWORK_ID]: {
-          provider: BASE_RPC_URL,
-          // Unlock contract address on Base mainnet
-          unlockAddress: '0xd0b14797b9D08493392865647384974470202A78',
-        },
-      };
-      const walletService = new WalletService(unlockConfig);
+      // Connect Unlock.js service
       console.log('Connecting Unlock service...');
       await walletService.connect(browserProvider as unknown as JsonRpcProvider);
 
@@ -141,8 +158,12 @@ export default function Home() {
       console.log('purchaseKey TX hash:', txHash);
 
       await checkMembership();
-    } catch (error) {
-      console.error('Purchase failed:', error);
+    } catch (error: any) {
+      if (error?.data) {
+        console.error('Purchase failed:', decodeUnlockError(error.data));
+      } else {
+        console.error('Purchase failed:', error);
+      }
     } finally {
       setIsPurchasing(false);
     }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -11,6 +11,7 @@ export function Providers({ children }: { children: ReactNode }) {
       config={{
         loginMethods: ['wallet'],
         appearance: {
+          showWalletLoginFirst: true,
           theme: 'light',
           accentColor: '#676FFF',
           walletChainType: 'ethereum-only',


### PR DESCRIPTION
## Summary
- keep a single Unlock wallet service instance
- show wallet login first in the Privy appearance config
- log detailed purchase failure reason
- decode Unlock contract revert codes

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: invalid Privy app ID)*

------
https://chatgpt.com/codex/tasks/task_e_688b6516593c8321abf6242a340ccbb0