### PR TITLE
Add token-gated CloudFront Lambda draft

### DIFF
--- a/lambda/generateSignedUrl.ts
+++ b/lambda/generateSignedUrl.ts
@@ -1,0 +1,54 @@
+import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
+import { Contract, JsonRpcProvider } from 'ethers';
+
+const LOCK_ADDRESS = process.env.LOCK_ADDRESS as string;
+const NETWORK_ID = Number(process.env.NETWORK_ID);
+const BASE_RPC_URL = process.env.BASE_RPC_URL as string;
+const CLOUDFRONT_DOMAIN = process.env.CLOUDFRONT_DOMAIN as string;
+const KEY_PAIR_ID = process.env.KEY_PAIR_ID as string;
+const PRIVATE_KEY = process.env.PRIVATE_KEY as string;
+
+const ABI = [
+  'function totalKeys(address) view returns (uint256)',
+  'function getHasValidKey(address) view returns (bool)',
+];
+
+export const handler = async (event: any) => {
+  const addr = event.queryStringParameters?.address as string;
+  const file = event.queryStringParameters?.file as string;
+
+  if (!addr || !file) {
+    return { statusCode: 400, body: 'Missing parameters' };
+  }
+
+  try {
+    const provider = new JsonRpcProvider(BASE_RPC_URL, NETWORK_ID);
+    const lock = new Contract(LOCK_ADDRESS, ABI, provider);
+
+    const total = await lock.totalKeys(addr);
+    if (total.toString() === '0') {
+      return { statusCode: 403, body: 'No membership' };
+    }
+
+    const valid = await lock.getHasValidKey(addr);
+    if (!valid) {
+      return { statusCode: 403, body: 'Membership expired' };
+    }
+
+    const expires = Math.floor(Date.now() / 1000) + 60 * 5; // 5 minutes
+    const url = getSignedUrl({
+      url: `https://${CLOUDFRONT_DOMAIN}/${file}`,
+      keyPairId: KEY_PAIR_ID,
+      dateLessThan: new Date(expires * 1000),
+      privateKey: PRIVATE_KEY,
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ url }),
+    };
+  } catch (err) {
+    console.error('Failed to generate URL', err);
+    return { statusCode: 500, body: 'Internal server error' };
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pgpforcrypto-community",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/cloudfront-signer": "^3.421.0",
         "@privy-io/react-auth": "^2.20.0",
         "@unlock-protocol/unlock-js": "^0.51.2",
         "ethers": "^6.15.0",
@@ -41,6 +42,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-sdk/cloudfront-signer": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/cloudfront-signer/-/cloudfront-signer-3.821.0.tgz",
+      "integrity": "sha512-5sDWEB23+eAzGklyjV1rYi4bSPWpG42N2+1WQhxF0491g5cElXwKN+eLgh/zT4Im3fq3Pum4Oj7P7SmMJLbATw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/url-parser": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2192,6 +2206,45 @@
       "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-9.0.1.tgz",
       "integrity": "sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==",
       "license": "MIT"
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
+      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
+      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "serve": "serve out -r '{\"source\": \"/community\",\"destination\": \"/community.html\"}' -r '{\"source\": \"/community/(.*)\",\"destination\": \"/$1\"}'"
   },
   "dependencies": {
+    "@aws-sdk/cloudfront-signer": "^3.421.0",
     "@privy-io/react-auth": "^2.20.0",
     "@unlock-protocol/unlock-js": "^0.51.2",
     "ethers": "^6.15.0",


### PR DESCRIPTION
## Summary
- add Lambda for checking Unlock membership and generating signed CloudFront URLs
- include `@aws-sdk/cloudfront-signer` dependency for the Lambda

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot initialize the Privy provider with an invalid Privy app ID)*

------
https://chatgpt.com/codex/tasks/task_e_688b8a8eee908321857513063baa76d7