### PR TITLE
Ensure lambda generates JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && mv out out-temp && mkdir -p out/community && mv out-temp/* out/community/ && rm -rf out-temp",
+    "build": "tsc -p tsconfig.lambda.json && next build && mv out out-temp && mkdir -p out/community && mv out-temp/* out/community/ && rm -rf out-temp",
     "start": "next start",
     "lint": "next lint",
     "serve": "serve out -r '{\"source\": \"/community\",\"destination\": \"/community.html\"}' -r '{\"source\": \"/community/(.*)\",\"destination\": \"/$1\"}'"

--- a/tsconfig.lambda.json
+++ b/tsconfig.lambda.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "commonjs",
+    "outDir": "./",
+    "rootDir": "./",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["lambda/generateSignedUrl.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- compile `lambda/generateSignedUrl.ts` during build
- add `tsconfig.lambda.json`

## Testing
- `npx tsc -p tsconfig.lambda.json && ls lambda`
- `npm run build` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_688bb49014b08321b5bf93721385dc86