### PR TITLE
Fix lambda packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ packaged for Lambda with:
 npm run build:lambda
 ```
 
-This command creates a bundled `generateSignedUrl.zip` archive at the repository
-root that can be uploaded to AWS Lambda. Configure the function's handler as
-`index.handler` when deploying the zip file.
+This command compiles the function into `lambda-build/index.js` and then zips
+the result into `generateSignedUrl.zip` at the repository root. Upload that zip
+file to AWS Lambda and configure the handler as `index.handler` when deploying.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build:lambda": "esbuild lambda/generateSignedUrl.ts --bundle --platform=node --target=node18 --format=cjs --tsconfig=tsconfig.lambda.json --outfile=lambda-build/index.js && (cd lambda-build && zip ../generateSignedUrl.zip index.js)",
+    "compile:lambda": "esbuild lambda/generateSignedUrl.ts --bundle --platform=node --target=node18 --format=cjs --tsconfig=tsconfig.lambda.json --outfile=lambda-build/index.js",
+    "package:lambda": "cd lambda-build && zip ../generateSignedUrl.zip index.js",
+    "build:lambda": "npm run compile:lambda && npm run package:lambda",
     "build": "npm run build:lambda && next build && mv out out-temp && mkdir -p out/community && mv out-temp/* out/community/ && rm -rf out-temp",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Summary
- break the lambda build script into compile and package steps
- document how to package the lambda

## Testing
- `npm run build:lambda`
- `npm run build` *(fails: Cannot initialize the Privy provider with an invalid Privy app ID)*

------
https://chatgpt.com/codex/tasks/task_e_688bc3db26848321ae118daa662866e9