### PR TITLE
Manual CloudFront URL signing

### DIFF
--- a/lambda/cloudFrontSigner.ts
+++ b/lambda/cloudFrontSigner.ts
@@ -1,0 +1,37 @@
+import { createSign } from 'crypto';
+
+export function getSignedUrl(params: {
+  url: string;
+  keyPairId: string;
+  privateKey: string;
+  expires: number; // epoch seconds
+}): string {
+  const policy = {
+    Statement: [
+      {
+        Resource: params.url,
+        Condition: {
+          DateLessThan: { 'AWS:EpochTime': params.expires },
+        },
+      },
+    ],
+  };
+
+  const policyString = JSON.stringify(policy);
+  const sign = createSign('RSA-SHA256');
+  sign.update(policyString);
+  sign.end();
+  const signature = sign.sign(params.privateKey);
+
+  const policyBase64 = Buffer.from(policyString).toString('base64');
+  const signatureBase64 = signature.toString('base64');
+
+  const urlSafe = (str: string) =>
+    str.replace(/\+/g, '-').replace(/=/g, '_').replace(/\//g, '~');
+
+  const signedUrl =
+    params.url +
+    `?Policy=${urlSafe(policyBase64)}&Signature=${urlSafe(signatureBase64)}&Key-Pair-Id=${params.keyPairId}`;
+
+  return signedUrl;
+}

--- a/lambda/generateSignedUrl.ts
+++ b/lambda/generateSignedUrl.ts
@@ -1,4 +1,4 @@
-import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
+import { getSignedUrl } from './cloudFrontSigner';
 import { Contract, JsonRpcProvider } from 'ethers';
 import {
   SecretsManagerClient,
@@ -58,7 +58,7 @@ export const handler = async (event: any) => {
     const url = getSignedUrl({
       url: `https://${CLOUDFRONT_DOMAIN}/${file}`,
       keyPairId: KEY_PAIR_ID,
-      dateLessThan: new Date(expires * 1000),
+      expires,
       privateKey,
     });
 


### PR DESCRIPTION
## Summary
- implement local CloudFront signer using Node `crypto`
- switch Lambda to use helper rather than `@aws-sdk/cloudfront-signer`

## Testing
- `npm run compile:lambda`

------
https://chatgpt.com/codex/tasks/task_e_688bcc85e7f883219823e33ab8db2952